### PR TITLE
Add pearl support for address validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ npm install crypto-address-validator-ts
 * Origin Protocol/ogn `'Origin Protocol'` or `'ogn'`
 * Orion Protocol/orn `'Orion Protocol'` or `'orn'`
 * Paxos/pax `'Paxos'` or `'pax'`
+* Pearl/pearl `'Pearl'` or `'pearl'`
 * PeerCoin/ppc `'PeerCoin'` or `'ppc'`
 * Perpetual Protocol/perp `'PeerCoin'` or `'perp'`
 * Phala Network/pha `'Phala Network'` or `'pha'`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fordefi-public/crypto-address-validator-ts",
-    "version": "0.5.22",
+    "version": "0.5.23",
     "description": "Crypto address validator for Bitcoin and other Altcoins, forked to be used with typescript",
     "keywords": [
         "typesript",

--- a/package.json
+++ b/package.json
@@ -398,7 +398,9 @@
         "1inch Network",
         "1inch",
         "IOTA",
-        "miota"
+        "miota",
+        "Pearl",
+        "pearl"
     ],
     "author": "Mark <mark.suurland@gmail.com>, Rony <rony@arnac.io>",
     "homepage": "https://github.com/marksuurland/crypto-address-validator-ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -16,6 +16,7 @@ import * as BIP173Validator from './validators/bip173_validator';
 import * as IOTAValidator from './validators/iota_validator';
 import * as XMRValidator from './validators/xmr_validator';
 import * as SOLValidator from './validators/sol_validator';
+import * as PearlValidator from './validators/pearl_validator';
 
 // defines P2PKH and P2SH address types for standard (prod) and testnet networks
 const CURRENCIES: Currency[] = [{
@@ -942,6 +943,12 @@ const CURRENCIES: Currency[] = [{
         symbol: 'miota',
         bech32Hrp: { prod: ['iota'], testnet: ['iota']},
         validator: IOTAValidator.isValidAddress,
+    },
+    {
+        name: 'Pearl',
+        symbol: 'pearl',
+        bech32Hrp: { prod: ['td'], testnet: ['td']},
+        validator: PearlValidator.isValidAddress,
     },
 ];
 

--- a/src/validators/pearl_validator.ts
+++ b/src/validators/pearl_validator.ts
@@ -1,0 +1,7 @@
+import { Currency, Options } from "../types/types";
+
+var segwit = require('../crypto/externals/segwit_addr');
+
+export function isValidAddress(address: string, currency: Currency, opts: Options): boolean {
+    return segwit.isValidAddress(address, currency, opts);
+}

--- a/tests/wallet_address_validator.ts
+++ b/tests/wallet_address_validator.ts
@@ -652,6 +652,18 @@ describe('validate', function () {
             valid('G4qGCGF4vWGPzYi2pxc2Djvgv3j8NiWaHQMgTVebCX6W', 'sol', null);
         });
 
+        it('should return true for correct pearl addresses', function () {
+            valid('td1p779g720f75k5duy9wdfuzd56wlffjw33vcxkxvd9kr3njatmlysqvs4y3j', 'pearl', null);
+        });
+
+        it('should return false for incorrect pearl addresses', function () {
+            invalid('', 'pearl', null);
+            invalid('%%@', 'pearl', null);
+            invalid('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4', 'pearl', null);
+            invalid('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', 'pearl', null);
+            invalid('td1p779g720f75k5duy9wdfuzd56wlffjw33vcxkxvd9kr3njatmlysqvs4y3k', 'pearl', null);
+        });
+
         it('should return true for correct iota addresses', function () {
             valid('iota1qpklumdlltn9mkmxmv2j34rtccv06c8eeatqn4fy44a0llzrwzx76t7yjqk', 'miota', null);
             invalid('1qpklumdlltn9mkmxmv2j34rtccv06c8eeatqn4fy44a0llzrwzx76t7yjqk', 'miota', null);


### PR DESCRIPTION
Add support for Pearl chain, it is the same as bitcoin but supports only Taproot addresses and has a different prefix