### PR TITLE
feat: add INJ validator supporting native bech32 and EVM addresses

### DIFF
--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -17,6 +17,7 @@ import * as IOTAValidator from './validators/iota_validator';
 import * as XMRValidator from './validators/xmr_validator';
 import * as SOLValidator from './validators/sol_validator';
 import * as PearlValidator from './validators/pearl_validator';
+import * as INJValidator from './validators/inj_validator';
 
 // defines P2PKH and P2SH address types for standard (prod) and testnet networks
 const CURRENCIES: Currency[] = [{
@@ -729,9 +730,10 @@ const CURRENCIES: Currency[] = [{
         validator: ETHValidator.isValidAddress,
     },
     {
-        name: 'Injective Protocol',
+        name: 'Injective',
         symbol: 'inj',
-        validator: ETHValidator.isValidAddress,
+        bech32Hrp: { prod: ['inj'], testnet: ['inj'] },
+        validator: INJValidator.isValidAddress,
     },
     {
         name: 'Illuvium',

--- a/src/validators/inj_validator.ts
+++ b/src/validators/inj_validator.ts
@@ -1,0 +1,12 @@
+import * as ETHValidator from './ethereum_validator';
+import * as BIP173Validator from './bip173_validator';
+import { Currency, Options } from '../types/types';
+
+export function isValidAddress(address: string, currency: Currency, opts: Options): boolean {
+    // Native Injective bech32 addresses (inj1...)
+    if (address.startsWith('inj1')) {
+        return BIP173Validator.isValidAddress(address, currency, opts);
+    }
+    // EVM addresses (0x...)
+    return ETHValidator.isValidAddress(address);
+}

--- a/tests/wallet_address_validator.ts
+++ b/tests/wallet_address_validator.ts
@@ -682,6 +682,26 @@ describe('validate', function () {
             valid('9uXRFi4PZMqhsnthBF6bGdfVnBSZtfKkR7Td8qPM7jUKZeTfR1tLhCoTLqYNE12xuiQg3aWGiLw83bWsqwTRLaM4Jk47xYM', 'XMR', { networkType: 'testnet' });
             valid('9tFTaQM39JXhULZsHauPHhjFrjcGSGXoijEPYoRgAky9Veck2mFp3EifQ2tKHmEHuuUoFfgYRNR2bVaborz5oi8JA8xkqjY', 'monero', { networkType: 'testnet' })
         });
+
+        it('should return true for correct injective addresses', function () {
+             // Native bech32 addresses
+             valid('inj1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqe2hm49', 'inj', null);
+             valid('inj1dzqd00lfd4y4qy2pxa0dsdwzfnmsu27hgttswz', 'INJ', null);
+             valid('inj1cml96vmptgw99syqrrz8az79xer2pcgp0a885r', 'injective', null);
+             valid('inj1cml96vmptgw99syqrrz8az79xer2pcgp0a885r', 'Injective', null);
+
+             // networkType options (prod and testnet share the same HRP)
+             valid('inj1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqe2hm49', 'inj', { networkType: 'prod' });
+             valid('inj1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqe2hm49', 'inj', { networkType: 'testnet' });
+             valid('inj1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqe2hm49', 'inj', { networkType: 'both' });
+
+             // EVM addresses (INJ is EVM-compatible)
+             valid('0xE37c0D48d68da5c5b14E5c1a9f1CFE802776D9FF', 'inj', null);
+             valid('0xa00354276d2fC74ee91e37D085d35748613f4748', 'INJ', null);
+             valid('0xAff4d6793F584a473348EbA058deb8caad77a288', 'injective', null);
+             valid('0xaff4d6793f584a473348eba058deb8caad77a288', 'inj', null); // all lowercase
+        });
+
     });
 
     describe('invalid results', function () {
@@ -1279,7 +1299,20 @@ describe('invalid results', function () {
         invalid('CxDDSH8gS7jecsxaRL8Txf8H5kqesLXAEAEgp76Yz632J9M', 'dot', null);
     });
 
+    it('should return false for incorrect injective addresses', function () {
+        commonTests('inj');
 
+        // bech32 specific
+        invalid('inj1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqe2hm4', 'inj', null); // wrong checksum/length
+        invalid('cosmos1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnrql8a', 'inj', null); // wrong prefix
+        invalid('inj2qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqcqt4fz', 'inj', null); // wrong prefix variant
+        invalid('inj1', 'inj', null); // prefix only, no data
+
+        // EVM specific
+        invalid('0xinvalid', 'inj', null);
+        invalid('0xE37c0D48d68da5c5b14E5c1a9f1CFE802776D9F', 'inj', null); // too short (39 hex chars)
+        invalid('0xE37c0D48d68da5c5b14E5c1a9f1CFE802776D9FFF', 'inj', null); // too long (41 hex chars)
+    });
 });
 
 


### PR DESCRIPTION
Add validation for native bech32(inj1...) and EVM(0x...) Injective addresses