### PR TITLE
Poll the registry before tagging a release [DEV-26502]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,9 @@ jobs:
           NAME: ${{ steps.check.outputs.name }}
           VERSION: ${{ steps.check.outputs.version }}
         run: |
-          if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
+          # --prefer-online revalidates rather than trusting cached metadata, so a stale hit
+          # cannot make us skip a release or attempt a duplicate one.
+          if npm view "$NAME@$VERSION" version --prefer-online >/dev/null 2>&1; then
             echo "$NAME@$VERSION is already published — nothing to release."
             echo "publish=false" >> "$GITHUB_OUTPUT"
           else
@@ -80,11 +82,12 @@ jobs:
 
       # `prepublishOnly` runs the whole gate (both test passes, publint, attw, the pack smoke
       # test) before anything is uploaded, so it is not repeated here.
-      - if: steps.decide.outputs.publish == 'true'
+      - id: publish
+        if: steps.decide.outputs.publish == 'true'
         run: npm publish
 
-      # Independent of the publish decision and idempotent, so a run that publishes but fails
-      # afterwards can be retried: it tags whatever is on the registry and has no tag yet.
+      # Idempotent, so a run that publishes but fails afterwards can be retried: it tags
+      # whatever is on the registry and has no tag yet.
       - name: Tag the commit and open a GitHub Release
         if: always() && steps.check.outputs.version != ''
         env:
@@ -92,11 +95,33 @@ jobs:
           NAME: ${{ steps.check.outputs.name }}
           VERSION: ${{ steps.check.outputs.version }}
           SHA: ${{ github.event.workflow_run.head_sha }}
+          # True when the version ought to be on the registry: we just published it, or it was
+          # already there. False only when `npm publish` itself failed.
+          EXPECTED: ${{ steps.publish.outcome == 'success' || steps.decide.outputs.publish == 'false' }}
         run: |
-          if ! npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
-            echo "$NAME@$VERSION is not on the registry — refusing to tag an unpublished version."
+          if [ "$EXPECTED" != 'true' ]; then
+            echo "npm publish did not succeed — refusing to tag an unpublished version."
             exit 0
           fi
+
+          # The registry is read-after-write eventually consistent: 0.6.0 was still reported
+          # missing 2s after a successful publish, which silently skipped tagging. Poll instead.
+          for attempt in $(seq 1 10); do
+            if npm view "$NAME@$VERSION" version --prefer-online >/dev/null 2>&1; then
+              published=yes
+              break
+            fi
+            echo "attempt $attempt: $NAME@$VERSION not visible on the registry yet; waiting 10s"
+            sleep 10
+          done
+
+          # Loud, not green: the publish succeeded, so failing to confirm it is a real problem.
+          # Re-running this workflow tags the release once the registry catches up.
+          if [ "${published:-}" != 'yes' ]; then
+            echo "::error::$NAME@$VERSION did not appear on the registry within 100s. It is published but untagged — re-run this workflow to tag it."
+            exit 1
+          fi
+
           if gh release view "v$VERSION" >/dev/null 2>&1; then
             echo "Release v$VERSION already exists."
             exit 0


### PR DESCRIPTION
## What happened

`0.6.0` published successfully but shipped **untagged**. Run [32343812700](https://github.com/arnac-io/crypto-address-validator-ts/actions/runs/32343812700) shows why:

```
07:32:45.79  npm notice publish  Provenance statement published to transparency log
07:32:47.99  @fordefi/crypto-address-validator-ts@0.6.0 is not on the registry — refusing to tag an unpublished version.
```

2.2 seconds after a successful publish, `npm view` still reported the version as absent. The guard written to prevent tagging an *unpublished* version instead skipped tagging a *just-published* one — and since that path `exit 0`s, the step reported ✓. A green run that silently did not do its job.

The tag and release for `v0.6.0` were created by hand; this fixes the workflow so the next release does not need that.

## Fix

- **Poll instead of a single read.** The npm registry is read-after-write eventually consistent. Up to ten attempts over 100s.
- **`--prefer-online`** on both registry reads, so cached metadata cannot produce a stale answer.
- **Loud, not green.** The step now separates two cases:
  - `npm publish` failed → declining to tag is correct, quiet `exit 0`
  - published but unconfirmable → `::error::` and `exit 1`

  This distinction is what `steps.publish.outcome` was added for. The step stays idempotent, so re-running tags the release once the registry catches up.

## Verification

The step was extracted and run against stubbed `npm`/`gh` across five scenarios:

| scenario | expected | result |
|---|---|---|
| `npm publish` failed | exit 0, no tag | ✅ |
| visible immediately | tags | ✅ |
| visible after 3 attempts | retries, then tags | ✅ |
| never visible | exit 1 + `::error::` | ✅ |
| release already exists | exit 0, no-op | ✅ |

Row 3 is the case that broke.

## Safe to merge

`package.json` is still at `0.6.0`, which is already published. So the release run this merge triggers will find the version present, find the tag present, and no-op. No republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)